### PR TITLE
Ensure database connection is closed, so we avoid leaking mysql connections

### DIFF
--- a/storage/mysql.go
+++ b/storage/mysql.go
@@ -86,6 +86,8 @@ func (mysql *MysqlRecord) searchRaw(typeTable string, name string, query string)
 		return nil, fmt.Errorf("Mysql connection error: %v", err)
 	}
 
+	defer db.Close()
+
 	// Filter input
 	name = filterString(name, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_")
 	query = filterString(query, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.-")


### PR DESCRIPTION
On `searchRaw` function a new mysql connection is opened every time, but never closed, leaking connections and hitting mysql server connection limit very fast.

Ensure db is closed by deferring the call right after we connect and didn't find any errors.